### PR TITLE
Fix: Find file pattern

### DIFF
--- a/bin/bourbon
+++ b/bin/bourbon
@@ -55,7 +55,7 @@ function run()
     for i=1, #files do
       file = files[i]
 
-      if file:find('.lua') then
+      if file:find('.lua$') then
         table.insert(paths, Path.join(testsPath, file))
       end
     end


### PR DESCRIPTION
The pattern used to find lua files in the test directory is not
correct and also matches some non-lua files like vim cache files.

I had two kind of artifacts matched that shouldn't have: .lua.swp or .lua~
files but I guess there can be more.

The issue isn't a big one since it doesn't break bourbon but
still it prints some annoying error messages on the output.
